### PR TITLE
Adding focus to Music OSD for menu access when Playback Controls are …

### DIFF
--- a/16x9/MusicOSD.xml
+++ b/16x9/MusicOSD.xml
@@ -154,6 +154,7 @@
 				<visible>Skin.HasSetting(HideOSDControls)</visible>
 				<include>HiddenControl</include>
 				<onclick>SetProperty(ShowOptions,1,home)</onclick>
+				<onclick>SetFocus(201)</onclick>
 				<onclick>8</onclick>
 			</control>
 			<!--Xray Icon-->


### PR DESCRIPTION
…hidden

When the option to hide playback controls is enabled the Music OSD menu is inaccessible using a remote as focus is not moved on from the hidden button. One line added to set focus to the first menu item once menu is visible. 

Tested under Linux.